### PR TITLE
Hotfix: Update Dockerfile to debian 12

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -102,7 +102,6 @@ jobs:
               "grant_type":"password",
               "prompt":"none", 
               "client_id": "kube-environment",
-              "scope": "openid",
               "username": "${{secrets.DEPLOY_USERNAME}}",
               "password": "${{secrets.DEPLOY_PASSWORD}}"
             }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,7 +1494,7 @@ dependencies = [
 
 [[package]]
 name = "spider-bot"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM --platform=$BUILDPLATFORM rust:1.72.1 as builder
+FROM --platform=$BUILDPLATFORM rust:1.72.1-bookworm as builder
 
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 ENV CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
@@ -25,7 +25,7 @@ RUN rustup target add $(cat /rust_target.txt)
 RUN cargo build --release --target $(cat /rust_target.txt)
 RUN cp ./target/$(cat /rust_target.txt)/release/spider-bot /spider-bot
 
-FROM gcr.io/distroless/cc as application
+FROM gcr.io/distroless/cc-debian12 as application
 
 COPY --from=builder /spider-bot /
 


### PR DESCRIPTION
Use debian 12 versions of rust and distroless.
Additionally, redundant scope parameter was removed from the docker-image.yml configuration.