### PR TITLE
Use stable rust toolchain version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.0
       - name: Set up Rust toolchain
-        uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
           components: rustfmt, clippy


### PR DESCRIPTION
The Rust toolchain version used in the continuous integration workflow was updated from a specific commit hash to "stable".  The previous commit hash constrained our workflow to an outdated version which may lack certain features or updates, thus potentially affecting the quality of our tests. Now, by targeting the "stable" channel, we aim to maintain our tools up-to-date with the latest stable versions, improving testing and building procedures.