### PR TITLE
Refactor background tasks and bot launch process

### DIFF
--- a/src/background_tasks.rs
+++ b/src/background_tasks.rs
@@ -1,84 +1,99 @@
-use serenity::client::Context;
+use std::sync::Arc;
+
+use serenity::builder::CreateEmbed;
+use serenity::http::Http;
 use serenity::model::prelude::ChannelId;
+use serenity::CacheAndHttp;
 use tokio::sync::mpsc::{channel, Receiver};
-use tracing::{error, info};
+use tracing::{info, instrument};
 
-use otaku::{DownloadCollection, Subscriber};
+use otaku::db::Pool;
+use otaku::{Download, DownloadCollection, Subscriber};
+use tenor::models::Gif;
 
+use crate::cache;
 use crate::consts::CACHE_TRIM_INTERVAL;
-use crate::SpiderBot;
 
-/// Core task spawning function. Creates a set of periodically recurring tasks on their own threads.
+/// Launch a periodic trim of the gif cache.
 ///
 /// ### Arguments
 ///
-/// - `bot` - the bot instance to delegate to tasks
-pub(crate) fn start_background_tasks(bot: &SpiderBot, context: Context) {
+/// - `gif_cache` - the cache of gifs
+pub(crate) fn start_cache_trim(gif_cache: cache::Memory<[Gif]>) {
+    let mut interval = tokio::time::interval(CACHE_TRIM_INTERVAL);
+    tokio::spawn(async move {
+        loop {
+            interval.tick().await;
+            gif_cache.trim().await;
+        }
+    });
+}
+
+/// Subscribe to announcements of new anime episodes from the anime api.
+///
+/// ### Arguments
+///
+/// - `pool` - the database connection pool
+/// - `anime_url` - the base url of the anime api
+/// - `discord` - the discord http client and cache
+pub(crate) fn start_anime_subscription(
+    pool: Pool,
+    anime_url: &'static str,
+    discord: Arc<CacheAndHttp>,
+) {
     let (tx, rx) = channel(16);
 
-    tokio::spawn(trim_cache(bot.gif_cache.clone()));
-    tokio::spawn(otaku::subscribe(bot.config.anime_url, bot.pool.clone(), tx));
-    tokio::spawn(embed_sender(context, rx));
+    tokio::spawn(otaku::subscribe(anime_url, pool, tx));
+    tokio::spawn(embed_sender(discord, rx));
 }
 
-async fn trim_cache<T>(cache: crate::cache::Memory<T>) -> anyhow::Result<()>
-where
-    T: ?Sized,
-{
-    let mut interval = tokio::time::interval(CACHE_TRIM_INTERVAL);
-    loop {
-        interval.tick().await;
-        cache.trim().await;
-    }
-}
-
-async fn embed_sender(context: Context, mut rx: Receiver<DownloadCollection>) {
+async fn embed_sender(discord: Arc<CacheAndHttp>, mut rx: Receiver<DownloadCollection>) {
     loop {
         if let Some(message) = rx.recv().await {
-            let channel_ids = message
-                .subscribers
-                .iter()
-                .filter_map(|s| match s {
-                    Subscriber::User(_) => None,
-                    Subscriber::Channel { channel_id, .. } => Some(channel_id),
-                })
-                .map(|&id| ChannelId(id));
-
+            let channel_ids = channel_ids(&message.subscribers);
             let title = message.episode.to_string();
-            let fields = message.downloads.iter().map(|d| {
-                (
-                    d.resolution.clone(),
-                    format!("[torrent]({})\n[comments]({})", d.torrent, d.comments),
-                    true,
-                )
-            });
+            info!(r#"Notifiying channels for: "{title}"#,);
+            let embed = create_embed(&title, message.downloads);
 
-            let mut success_count = 0usize;
             for channel_id in channel_ids {
-                let result = channel_id
-                    .send_message(&context.http, |m| {
-                        m.embed(|e| e.title(&title).fields(fields.clone()))
-                    })
-                    .await;
-
-                match result {
-                    Ok(_) => success_count += 1,
-                    Err(err) => {
-                        let channel = context.cache.channel(channel_id);
-                        error!(
-                            r#"Failed to send message for "{}" to {:?}. Due to {}"#,
-                            title, channel, err
-                        );
-                    }
-                }
-            }
-
-            if success_count > 0 {
-                info!(
-                    r#"Successfully notified {:?} channels for: "{}"#,
-                    success_count, title
-                );
+                tokio::spawn(send_embed(discord.http.clone(), channel_id, embed.clone()));
             }
         }
     }
+}
+
+fn create_embed(title: &str, downloads: Vec<Download>) -> CreateEmbed {
+    let mut embed = CreateEmbed::default();
+    embed.title(title);
+    for d in downloads {
+        embed.field(
+            d.resolution,
+            format!("[torrent]({})\n[comments]({})", d.torrent, d.comments),
+            true,
+        );
+    }
+
+    embed
+}
+
+fn channel_ids(subscribers: &[Subscriber]) -> impl Iterator<Item = ChannelId> + '_ {
+    subscribers
+        .iter()
+        .filter_map(|s| match s {
+            Subscriber::User(_) => None,
+            Subscriber::Channel { channel_id, .. } => Some(channel_id),
+        })
+        .map(|&id| ChannelId(id))
+}
+
+#[instrument(skip(http), err(Debug))]
+async fn send_embed(
+    http: Arc<Http>,
+    channel_id: ChannelId,
+    embed: CreateEmbed,
+) -> Result<(), serenity::Error> {
+    channel_id
+        .send_message(http, |m| m.set_embed(embed.clone()))
+        .await?;
+    Ok(())
 }


### PR DESCRIPTION
Refactor to simplify the SpiderBot struct, separate background tasks into individual functions, and bring clarity to the bot launch process. The AtomicBool was removed, as the tasks are always running in the current implementation. Functions 'start_cache_trim' and 'start_anime_subscription' were added for improved modularity and clarity. Embed sender was also improved for better error handling.