### PR TITLE
Refactor notification logic in `background_tasks`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "otaku"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "chrono",
  "futures-util",

--- a/otaku/Cargo.toml
+++ b/otaku/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "otaku"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
The `otaku` library version was updated from 0.1.3 to 0.1.4. Significant refactoring was carried out in `src/background_tasks.rs` to improve code organization and error handling. A newly introduced function, `process_downloads_subscription`, separates the processing of subscribed downloads and sending of notifications into individual steps. This ensures that notification sending continues even if one fails. The individual subscriber information has been extended to include more data, allowing for improved error messages. The `otaku/src/lib.rs` also gained additional error types to better represent various error scenarios. Additionally, redundant code in `otaku/Cargo.toml` and `otaku/src/lib.rs` was updated/removed.