### PR TITLE
Update spider-bot to v0.1.11 enabling multiple download variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,7 +1326,7 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "otaku"
-version = "0.1.7"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "futures-util",
@@ -1545,7 +1545,7 @@ dependencies = [
 
 [[package]]
 name = "proto"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "prost",
  "prost-types",
@@ -2007,7 +2007,7 @@ dependencies = [
 
 [[package]]
 name = "spider-bot"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spider-bot"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Stefan Breetveld <spiderbiggen@gmail.com>"]
 edition = "2021"
 description = "Discord bot for the 'Turtle Force' discord"

--- a/otaku/Cargo.toml
+++ b/otaku/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "otaku"
-version = "0.1.7"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "proto"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -1,6 +1,8 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // trigger recompilation when a new migration is added
     println!("cargo:rerun-if-changed=protos");
-    tonic_build::compile_protos("protos/api.v1.proto")?;
+    tonic_build::configure()
+        .emit_rerun_if_changed(true)
+        .compile(&["protos/api.v1.proto", "protos/api.v2.proto"], &["protos"])?;
     Ok(())
 }

--- a/proto/protos/api.v2.proto
+++ b/proto/protos/api.v2.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package api.v2;
+
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/empty.proto";
+
+message Batch {
+  uint32 start = 4;
+  uint32 end = 5;
+}
+
+message Episode {
+  uint32 number = 4;
+  uint32 decimal = 5;
+  uint32 version = 6;
+  string extra = 7;
+}
+
+message Movie {};
+
+message DownloadCollection {
+    string title = 1;
+    repeated Download downloads = 2;
+    google.protobuf.Timestamp created_at = 3;
+    google.protobuf.Timestamp updated_at = 4;
+    oneof variant {
+       Batch batch = 5;
+       Episode episode = 6;
+       Movie movie = 7;
+    };
+}
+
+message Download {
+  google.protobuf.Timestamp published_date = 2;
+  uint32 resolution = 3;
+  string comments = 4;
+  string torrent = 5;
+  string file_name = 6;
+}
+
+service Downloads {
+    rpc Subscribe (google.protobuf.Empty) returns (stream DownloadCollection) {};
+}

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -4,4 +4,9 @@ pub mod api {
         #![allow(clippy::derive_partial_eq_without_eq)]
         tonic::include_proto!("api.v1");
     }
+    pub mod v2 {
+        #![allow(clippy::large_enum_variant)]
+        #![allow(clippy::derive_partial_eq_without_eq)]
+        tonic::include_proto!("api.v2");
+    }
 }

--- a/src/background_tasks.rs
+++ b/src/background_tasks.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use std::sync::Arc;
 
 use serenity::all::CreateMessage;
@@ -74,9 +75,9 @@ async fn process_downloads_subscription(
 ) {
     let channel_ids = channel_ids(&message.subscribers);
 
-    let title = message.content.episode.to_string();
+    let title = format!("{} {}", message.content.title, message.content.variant,);
     tracing::Span::current().record("title", &title);
-    let embed = create_embed(&title, message.content.downloads);
+    let embed = create_embed(title, message.content.downloads, message.content.created_at);
 
     info!("Notifying {} channels", channel_ids.len());
     for channel_id in channel_ids {
@@ -89,12 +90,11 @@ async fn process_downloads_subscription(
     }
 }
 
-fn create_embed(title: &str, downloads: Vec<Download>) -> CreateEmbed {
-    let mut embed = CreateEmbed::default();
-    embed = embed.title(title);
+fn create_embed(title: String, downloads: Vec<Download>, timestamp: DateTime<Utc>) -> CreateEmbed {
+    let mut embed = CreateEmbed::new().title(title).timestamp(timestamp);
     for d in downloads {
         embed = embed.field(
-            d.resolution,
+            format!("{}p", d.resolution),
             format!("[torrent]({})\n[comments]({})", d.torrent, d.comments),
             true,
         );


### PR DESCRIPTION
Introduce a new DownloadVariant to support different episodic formats. Several modules have been adjusted to be compatible with the new version.